### PR TITLE
カレンダーと習慣記録の紐づけ

### DIFF
--- a/app/assets/stylesheets/calender.css
+++ b/app/assets/stylesheets/calender.css
@@ -44,9 +44,55 @@
   font-weight: 500;
 }
 
+/* Completed day styling - full green background */
+.simple-calendar .day .completed-day {
+  background-color: #d4edda !important;
+  border-radius: 8px;
+  border: 2px solid #28a745;
+}
+
+/* Alternative approach for completed day styling */
+.calendar-date.completed-day {
+  background-color: #d4edda !important;
+  border-radius: 8px;
+  border: 2px solid #28a745 !important;
+  box-shadow: 0 2px 4px rgba(40, 167, 69, 0.2);
+}
+
+.simple-calendar .day:has(.completed-day) {
+  background-color: #d4edda !important;
+}
+
+.simple-calendar .day .calendar-date {
+  cursor: pointer;
+  display: block;
+  height: 100%;
+  width: 100%;
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.no-record-indicator {
+  color: #6c757d;
+  font-style: italic;
+}
+
 .simple-calendar .day:hover {
   background-color: #f8f9fa;
 }
+
+/* Calendar date interaction */
+.calendar-date:hover {
+  background-color: #e3f2fd !important;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.calendar-date:active {
+  transform: scale(0.98);
+  transition: transform 0.1s ease;
+}
+
 
 .simple-calendar .today {
   background-color: #e3f2fd !important;
@@ -106,15 +152,16 @@
 }
 
 .calendar-event.completed {
-  background-color: #d4edda;
+  background-color: transparent;
   color: #155724;
-  border-left: 3px solid #28a745;
+  border: none;
 }
 
-.calendar-event.incomplete {
-  background-color: #fff3cd;
-  color: #856404;
-  border-left: 3px solid #ffc107;
+.completion-check {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #28a745;
+  text-shadow: 1px 1px 2px rgba(0,0,0,0.1);
 }
 
 .calendar-event .badge {

--- a/app/controllers/habit_record_controller.rb
+++ b/app/controllers/habit_record_controller.rb
@@ -1,0 +1,65 @@
+class HabitRecordsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_habit
+  before_action :set_habit_record, only: [:show, :update, :destroy]
+
+  # GET /habits/:habit_id/habit_records/:id
+  def show
+    respond_to do |format|
+      format.html
+      format.json { render json: @habit_record }
+    end
+  end
+
+  # POST /habits/:habit_id/habit_records
+  def create
+    @habit_record = @habit.habit_records.build(habit_record_params)
+    @habit_record.user = current_user
+
+    respond_to do |format|
+      if @habit_record.save
+        format.html { redirect_to calendar_habit_path(@habit), notice: '記録が作成されました。' }
+        format.json { render json: @habit_record, status: :created }
+      else
+        format.html { redirect_to calendar_habit_path(@habit), alert: '記録の作成に失敗しました。' }
+        format.json { render json: @habit_record.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /habits/:habit_id/habit_records/:id
+  def update
+    respond_to do |format|
+      if @habit_record.update(habit_record_params)
+        format.html { redirect_to calendar_habit_path(@habit), notice: '記録が更新されました。' }
+        format.json { render json: @habit_record }
+      else
+        format.html { redirect_to calendar_habit_path(@habit), alert: '記録の更新に失敗しました。' }
+        format.json { render json: @habit_record.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /habits/:habit_id/habit_records/:id
+  def destroy
+    @habit_record.destroy
+    respond_to do |format|
+      format.html { redirect_to calendar_habit_path(@habit), notice: '記録が削除されました。' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  def set_habit
+    @habit = current_user.habits.find(params[:habit_id])
+  end
+
+  def set_habit_record
+    @habit_record = @habit.habit_records.find(params[:id])
+  end
+
+  def habit_record_params
+    params.require(:habit_record).permit(:recorded_at, :completed, :note)
+  end
+end

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -1,6 +1,6 @@
 class HabitsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_habit, only: [:show, :edit, :update, :destroy, :individual_calendar]
+  before_action :set_habit, only: [:show, :edit, :update, :destroy, :individual_calendar, :toggle_record_for_date]
 
   def index
     @habits = current_user.habits.recent
@@ -12,6 +12,54 @@ class HabitsController < ApplicationController
   def individual_calendar
     @habit_records = @habit.habit_records.includes(:habit)
   end
+
+  def toggle_record_for_date
+    begin
+      date = Date.parse(params[:date])
+    rescue ArgumentError => e
+      respond_to do |format|
+        format.json { render json: { success: false, error: "Invalid date format: #{params[:date]}" }, status: :bad_request }
+      end
+      return
+    end
+
+    record = @habit.habit_records.find_by(recorded_at: date, user: current_user)
+
+    if record
+      # Delete existing record (toggle from completed to unrecorded)
+      record.destroy!
+      Rails.logger.info "Deleted habit record for habit #{@habit.id}, date #{date}, user #{current_user.id}"
+    else
+      # Create new completed record
+      new_record = @habit.habit_records.build(
+        user: current_user,
+        recorded_at: date,
+        completed: true
+      )
+
+      if new_record.save
+        Rails.logger.info "Created habit record for habit #{@habit.id}, date #{date}, user #{current_user.id}"
+      else
+        Rails.logger.error "Failed to create habit record: #{new_record.errors.full_messages.join(', ')}"
+        respond_to do |format|
+          format.json { render json: { success: false, error: "Failed to create record: #{new_record.errors.full_messages.join(', ')}" }, status: :unprocessable_entity }
+        end
+        return
+      end
+    end
+
+    respond_to do |format|
+      format.json { render json: { success: true } }
+    end
+
+  rescue => e
+    Rails.logger.error "Unexpected error in toggle_record_for_date: #{e.class.name}: #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+    respond_to do |format|
+      format.json { render json: { success: false, error: "Unexpected error: #{e.message}" }, status: :internal_server_error }
+    end
+  end
+
 
   def new
     @habit = current_user.habits.build

--- a/app/helpers/habit_record_helper.rb
+++ b/app/helpers/habit_record_helper.rb
@@ -1,0 +1,2 @@
+module HabitRecordHelper
+end

--- a/app/helpers/habits_helper.rb
+++ b/app/helpers/habits_helper.rb
@@ -18,10 +18,6 @@ module HabitsHelper
   end
 
   def habit_status_badge(record)
-    if record.completed?
-      content_tag(:span, "✓", class: "badge bg-success", title: "完了")
-    else
-      content_tag(:span, "○", class: "badge bg-warning text-dark", title: "未完了")
-    end
+    content_tag(:span, "✓", class: "badge bg-success", title: "完了")
   end
 end

--- a/app/models/habit_record.rb
+++ b/app/models/habit_record.rb
@@ -3,7 +3,7 @@ class HabitRecord < ApplicationRecord
   belongs_to :habit
 
   validates :recorded_at, presence: true
-  validates :notes, length: { maximum: 1000 }
+  validates :note, length: { maximum: 1000 }
   validates :completed, inclusion: { in: [true, false] }
   validates :user_id, uniqueness: { scope: [:habit_id, :recorded_at],
                                    message: "can only have one record per habit per day" }

--- a/app/views/habits/individual_calendar.html.erb
+++ b/app/views/habits/individual_calendar.html.erb
@@ -1,4 +1,4 @@
-<div class="container mt-4">
+<div class="container mt-4" data-habit-id="<%= @habit.id %>">
   <div class="d-flex justify-content-between align-items-center mb-4">
     <h1><%= @habit.title %> - カレンダー</h1>
     <div class="btn-group" role="group">
@@ -9,46 +9,30 @@
 
   <div class="card">
     <div class="card-body">
-      <% begin %>
-        <%= month_calendar(events: @habit_records, attribute: :recorded_at) do |date, records| %>
+      <div class="alert alert-info mb-3">
+        <h6 class="alert-heading mb-2">💡 使い方</h6>
+        <p class="mb-0">カレンダーの日付をクリックして習慣の達成状況を記録できます。クリックするたびに「完了」と「未記録」が切り替わります。<br><small class="text-muted">※3日前までの日付のみクリック可能です</small></p>
+      </div>
+
+      <%= month_calendar(events: @habit_records, attribute: :recorded_at) do |date, records| %>
+        <div class="calendar-date <%= 'completed-day' if records.any? %>" data-date="<%= date.strftime('%Y-%m-%d') %>" style="cursor: pointer; height: 100%;">
           <%= date.day %>
 
           <% if records.any? %>
             <div class="calendar-events mt-2">
               <% records.each do |record| %>
-                <div class="calendar-event <%= record.completed? ? 'completed' : 'incomplete' %>"
-                     title="<%= @habit.title %> - <%= record.completed? ? '完了' : '未完了' %>">
-                  <small class="d-block">
-                    <%= habit_status_badge(record) %>
-                    <% if record.notes.present? %>
-                      <span class="text-muted" title="<%= record.notes %>">📝</span>
-                    <% end %>
-                  </small>
+                <div class="calendar-event completed"
+                     title="<%= @habit.title %> - 完了">
+                  <span class="completion-check">✓</span>
+                  <% if record.note.present? %>
+                    <span class="text-muted" title="<%= record.note %>">📝</span>
+                  <% end %>
                 </div>
               <% end %>
             </div>
-          <% end %>
-        <% end %>
-      <% rescue NameError %>
-        <div class="alert alert-warning">
-          <h5>カレンダー機能の準備中</h5>
-          <p>カレンダー表示には <code>simple_calendar</code> gemのインストールが必要です。</p>
-          <p>以下のコマンドを実行してください:</p>
-          <pre><code>bundle install</code></pre>
-        </div>
-
-        <!-- Fallback: Simple list view -->
-        <div class="mt-4">
-          <h5>今月の「<%= @habit.title %>」の記録</h5>
-          <% @habit_records.where(recorded_at: Date.current.beginning_of_month..Date.current.end_of_month).order(:recorded_at).each do |record| %>
-            <div class="d-flex justify-content-between align-items-center border-bottom py-2">
-              <div>
-                <strong><%= record.recorded_at.strftime("%Y年%m月%d日") %></strong>
-                <% if record.notes.present? %>
-                  <small class="text-muted d-block"><%= record.notes %></small>
-                <% end %>
-              </div>
-              <%= habit_status_badge(record) %>
+          <% else %>
+            <div class="no-record-indicator" style="opacity: 0.5; font-size: 0.8em; margin-top: 4px;">
+              未記録
             </div>
           <% end %>
         </div>
@@ -93,9 +77,6 @@
             <span class="badge bg-success">✓</span> 完了した日
           </div>
           <div class="mb-2">
-            <span class="badge bg-warning">○</span> 未完了の日
-          </div>
-          <div class="mb-2">
             <span class="text-muted">📝</span> メモ付きの記録
           </div>
         </div>
@@ -103,3 +84,128 @@
     </div>
   </div>
 </div>
+
+<script>
+
+// Define the handler function globally to avoid multiple bindings
+let calendarInitialized = false;
+
+function handleDateClick(event) {
+  const dateElement = event.currentTarget;
+  const date = dateElement.dataset.date;
+  const habitId = parseInt(dateElement.closest('[data-habit-id]')?.dataset.habitId || '<%= @habit.id %>');
+
+  if (!date) {
+    console.error('No date found on element:', dateElement);
+    return;
+  }
+
+  const currentDate = new Date();
+  currentDate.setHours(23, 59, 59, 999); // Set to end of day for comparison
+  const selectedDate = new Date(date + 'T00:00:00'); // Ensure date is parsed as local time
+  const threeDaysAgo = new Date();
+  threeDaysAgo.setDate(currentDate.getDate() - 3);
+  threeDaysAgo.setHours(0, 0, 0, 0); // Set to start of day for comparison
+
+ console.log('Date clicked:', date, 'Selected:', selectedDate, 'Three days ago:', threeDaysAgo, 'Current:', currentDate);
+
+  // Allow interaction with dates from 3 days ago up to today
+  if (selectedDate >= threeDaysAgo && selectedDate <= currentDate) {
+    toggleRecord(habitId, date, dateElement);
+  } else {
+    alert('3日前までの日付のみ記録可能です。');
+  }
+}
+
+function toggleRecord(habitId, date, dateElement) {
+  console.log('Toggling record for habit', habitId, 'on date', date);
+
+  // Add loading state
+  dateElement.style.opacity = '0.5';
+
+  // Get CSRF token
+  const csrfToken = document.querySelector('[name="csrf-token"]')?.content;
+  if (!csrfToken) {
+    console.error('CSRF token not found');
+    alert('認証トークンが見つかりません。ページを再読み込みしてください。');
+    dateElement.style.opacity = '1';
+    return;
+  }
+
+  console.log('Making request to:', `/habits/${habitId}/toggle_record_for_date`);
+  console.log('Request body:', { date: date });
+
+
+  fetch(`/habits/${habitId}/toggle_record_for_date`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': csrfToken,
+      'Accept': 'application/json'
+    },
+    body: JSON.stringify({ date: date })
+  })
+  .then(response => {
+    console.log('Response status:', response.status);
+     console.log('Response headers:', response.headers);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    return response.json();
+  })
+  .then(data => {
+    console.log('Response data:', data);
+    if (data.success) {
+      // Reload the page to show updated state
+      console.log('Success! Reloading page...');
+      window.location.reload();
+    } else {
+      alert('記録の更新に失敗しました: ' + (data.error || '不明なエラー'));
+      dateElement.style.opacity = '1';
+    }
+  })
+  .catch(error => {
+    console.error('Error:', error);
+    alert('記録の更新中にエラーが発生しました: ' + error.message);
+    dateElement.style.opacity = '1';
+  });
+}
+
+function initializeCalendar() {
+  // Prevent multiple initializations
+  if (calendarInitialized) {
+    console.log('Calendar already initialized, skipping...');
+    return;
+  }
+
+  const calendarDates = document.querySelectorAll('.calendar-date');
+
+  console.log('Initializing calendar with', calendarDates.length, 'date elements');
+
+  calendarDates.forEach(function(dateElement) {
+    // Remove any existing listeners first
+    dateElement.removeEventListener('click', handleDateClick);
+    // Add the listener
+    dateElement.addEventListener('click', handleDateClick);
+  });
+
+  calendarInitialized = true;
+  console.log('Calendar initialization complete');
+}
+
+// Reset the flag when navigating away
+function resetCalendarFlag() {
+  calendarInitialized = false;
+}
+
+// Initialize on page load
+document.addEventListener('DOMContentLoaded', initializeCalendar);
+
+// Handle Turbo navigation
+document.addEventListener('turbo:load', function() {
+  resetCalendarFlag();
+  initializeCalendar();
+});
+
+document.addEventListener('turbo:before-visit', resetCalendarFlag);
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
    resources :habits do
     member do
       get :calendar, to: 'habits#individual_calendar'
+      post :toggle_record_for_date, to: 'habits#toggle_record_for_date'
     end
-  end
+    resources :habit_records, except: [:index, :new, :edit]
+    end
 end

--- a/test/controllers/habit_record_controller_test.rb
+++ b/test/controllers/habit_record_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class HabitRecordControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
＃概要
カレンダーと習慣記録の紐づけ

・各習慣ごとのカレンダーに3日以内の日付をワンクリックで記録でき日付にチェックマークがつき緑色に変化する。もう一度クリックすると元に戻る
・3日以内の画面に記録しようとすると「3日以内の日付のみ記録可能です。」のアラート表示
・カレンダーの記録機能のAjax対応
・記録機能をもとに、今月の完了率の表示


