### PR TITLE
プロフィール編集

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  private
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,10 @@ class User < ApplicationRecord
   has_many :habits, dependent: :destroy
   has_many :habit_records, dependent: :destroy
   has_many :posts, dependent: :destroy
+
+  # Method to return name if present, otherwise email prefix
+  def display_name
+    name.present? ? name : email.split('@').first
+  end
 end
+

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -20,6 +20,16 @@
             <% end %>
 
             <div class="mb-4">
+              <%= form.label :name, "名前", class: "form-label fw-bold", style: "font-size: 1.2rem;" %>
+              <div class="mt-2">
+                <%= form.text_field :name, autocomplete: "name",
+                    class: "form-control form-control-lg",
+                    placeholder: "名前を入力してください（任意）",
+                    style: "font-size: 1.1rem; padding: 1rem; width: 30%" %>
+              </div>
+            </div>
+
+            <div class="mb-4">
               <%= form.label :email, "メールアドレス", class: "form-label fw-bold", style: "font-size: 1.2rem;" %>
               <div class="mt-2">
                 <%= form.email_field :email, autofocus: true, autocomplete: "email",

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -20,6 +20,16 @@
             <% end %>
 
             <div class="mb-4">
+              <%= form.label :name, "名前", class: "form-label fw-bold", style: "font-size: 1.2rem;" %>
+              <div class="mt-2">
+                <%= form.text_field :name, autocomplete: "name",
+                    class: "form-control form-control-lg",
+                    placeholder: "名前を入力してください（任意）",
+                    style: "font-size: 1.1rem; padding: 1rem; width: 25%" %>
+              </div>
+            </div>
+
+            <div class="mb-4">
               <%= form.label :email, "メールアドレス", class: "form-label fw-bold", style: "font-size: 1.2rem;" %>
               <div class="mt-2">
                 <%= form.email_field :email, autofocus: true, autocomplete: "email",

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -18,7 +18,7 @@
                   🎯 <%= post.habit.title %>
                 </h3>
                 <small class="text-white-50">
-                  👤 <%= post.user.email.split('@').first %> •
+                  👤 <%= post.user.display_name%> •
                   ⏰ <%= time_ago_in_words(post.created_at) %>前
                 </small>
               </div>

--- a/db/migrate/20250907162304_add_name_to_users.rb
+++ b/db/migrate/20250907162304_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_05_141505) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_07_162304) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_05_141505) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
＃概要
プロフィール編集

・usersテーブルにnameカラムの追加。
・プロフィール編集や新規作成する際に名前が入力できるよう修正。
・みんなの投稿一覧ページで作成者の欄にusersテーブルのnameが表示されるよう設定