### PR TITLE
作成者表示修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,9 +8,8 @@ class User < ApplicationRecord
   has_many :habit_records, dependent: :destroy
   has_many :posts, dependent: :destroy
 
-  # Method to return name if present, otherwise email prefix
+  # 名前が空の場合、ゲストを表示名として返す
   def display_name
-    name.present? ? name : email.split('@').first
+    name.present? ? name : "ゲスト"
   end
 end
-

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,7 +11,7 @@
           </h1>
           <p class="card-text"><%= simple_format(@post.content) %></p>
           <small class="text-muted">
-            by <%= @post.user.email.split('@').first %> •
+            by <%= @post.user.display_name %> •
             <%= @post.created_at.strftime("%Y年%m月%d日 %H:%M") %>
           </small>
 


### PR DESCRIPTION
＃概要
作成者表示修正

みんなの投稿一覧の投稿の作成者に自分の名前かメールアドレスが表示されるようになっていたので、メールアドレスの代わりに"ゲスト"と表示されるよう修正