### PR TITLE
プロフィール編集機能修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
 


### PR DESCRIPTION
＃概要
プロフィール編集機能修正

プロフィール編集の名前変更ができなかったので、できるよう修正