### PR TITLE
タグ機能追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
+/vendor/bundle
 
 # Ignore all environment files (except templates).
 /.env*

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,12 @@ class PostsController < ApplicationController
   before_action :set_post, only: [:edit, :update, :destroy]
 
   def index
-    @posts = Post.with_associations.recent.limit(50)
+    if params[:tag].present?
+      @posts = Post.tagged_with(params[:tag]).with_associations.recent.limit(50)
+      @current_tag = params[:tag]
+    else
+      @posts = Post.with_associations.recent.limit(50)
+    end
   end
 
   def new
@@ -66,6 +71,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:habit_id, :content, :image)
+    params.require(:post).permit(:habit_id, :content, :image, :tag_list)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,10 +1,26 @@
 class Post < ApplicationRecord
   belongs_to :user
   belongs_to :habit
+  has_many :post_tags, dependent: :destroy
+  has_many :tags, through: :post_tags
 
   validates :content, presence: true, length: { maximum: 1000 }
   validates :image, length: { maximum: 255 }
 
   scope :recent, -> { order(created_at: :desc) }
-  scope :with_associations, -> { includes(:user, :habit) }
+  scope :with_associations, -> { includes(:user, :habit, :tags) }
+  scope :tagged_with, ->(tag_name) { joins(:tags).where(tags: { name: tag_name }) }
+
+  # 投稿に紐づいているタグをカンマ区切りの文字列で返す。
+  def tag_list
+    tags.pluck(:name).join(', ')
+  end
+
+  # カンマ区切り, 空白削除, 重複削除したタグ名の配列を受け取り、タグを関連付ける。
+  def tag_list=(names)
+    tag_names = names.split(',').map(&:strip).reject(&:blank?).uniq
+    self.tags = tag_names.map do |name|
+      Tag.find_or_create_by(name: name)
+    end
+  end
 end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,0 +1,6 @@
+class PostTag < ApplicationRecord
+  belongs_to :post
+  belongs_to :tag
+
+  validates :post_id, uniqueness: { scope: :tag_id }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,18 @@
+class Tag < ApplicationRecord
+  has_many :post_tags, dependent: :destroy
+  has_many :posts, through: :post_tags
+
+  validates :name, presence: true, uniqueness: true, length: { maximum: 50 }
+  validates :name, format: { with: /\A[a-zA-Z0-9_\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]+\z/, message: "は文字、数字、アンダースコアのみ使用できます" }
+
+  before_save :normalize_name
+
+  scope :popular, -> { joins(:posts).group('tags.id').order('COUNT(posts.id) DESC') }
+
+  private
+
+  # 空白を削除し、小文字に変換
+  def normalize_name
+    self.name = name.strip.downcase if name
+  end
+end

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -32,7 +32,7 @@
             <div class="mb-5">
               <%= form.label :content, "投稿内容", class: "form-label fw-bold", style: "font-size: 1.3rem;" %>
               <div class="mt-2">
-                <%= form.text_area :content, class: "form-control form-control-lg w-100", rows: 8,
+                <%= form.text_area :content, class: "form-control form-control-lg w-100", rows: 6,
                     placeholder: "今日の習慣の取り組みや感想を書いてください...",
                     style: "font-size: 1.1rem; padding: 1.5rem; line-height: 1.6; resize: vertical; width: 70%;" %>
             </div>
@@ -43,7 +43,17 @@
                 <%= form.text_field :image, class: "form-control form-control-lg w-100",
                     placeholder: "画像のURLを入力してください（任意）",
                     style: "font-size: 1.1rem; padding: 1.5rem; width: 70%;" %>
-                <small class="form-text text-muted mt-2" style="font-size: 1rem;">習慣に関連する画像のURLを入力できます</small>
+                <small class="form-text text-muted mt-2" style: "font-size: 1rem;">習慣に関連する画像のURLを入力できます</small>
+              </div>
+            </div>
+
+            <div class="mb-5">
+              <%= form.label :tag_list, "タグ", class: "form-label fw-bold", style: "font-size: 1.3rem;" %>
+              <div class="mt-2">
+                <%= form.text_field :tag_list, class: "form-control form-control-lg w-100",
+                    placeholder: "勉強, 運動, 読書 (カンマ区切りで複数入力可)",
+                    style: "font-size: 1.1rem; padding: 1.5rem; width: 35%;" %>
+                <small class="form-text text-muted mt-2" style="font-size: 1rem;">タグをカンマ区切りで入力してください（例：勉強, 運動, 読書）</small>
               </div>
             </div>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,7 +1,13 @@
 <div class="dashboard-section">
   <div class="container">
     <h1 class="dashboard-title">📌 みんなの習慣一覧</h1>
-    <p class="dashboard-subtitle">コミュニティのメンバーが共有している習慣の取り組みをご覧ください</p>
+    <% if @current_tag.present? %>
+      <p class="dashboard-subtitle">タグ「#<%= @current_tag %>」の投稿を表示中
+        <%= link_to "すべて表示", posts_path, class: "btn btn-outline-secondary btn-sm ms-2" %>
+      </p>
+    <% else %>
+      <p class="dashboard-subtitle">コミュニティのメンバーが共有している習慣の取り組みをご覧ください</p>
+    <% end %>
 
     <div class="text-center mb-4">
       <%= link_to "投稿する", new_post_path, class: "btn btn-primary btn-lg" %>
@@ -25,6 +31,15 @@
               <div class="card-content">
                 <% if post.image.present? %>
                   <img src="<%= post.image %>" class="img-fluid mb-3 rounded" alt="投稿画像" style="max-height: 200px; width: 100%; object-fit: cover;">
+                <% end %>
+                <% if post.tags.any? %>
+                  <div class="mb-3">
+                    <% post.tags.each do |tag| %>
+                      <%= link_to "##{tag.name}", posts_path(tag: tag.name),
+                          class: "badge bg-primary text-decoration-none me-2 mb-1",
+                          style: "font-size: 0.9rem; padding: 0.5rem 0.75rem;" %>
+                    <% end %>
+                  </div>
                 <% end %>
                 <p style="font-size: 1rem; line-height: 1.6; margin-bottom: 1.5rem;">
                   <%= simple_format(post.content) %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -32,7 +32,7 @@
             <div class="mb-5">
               <%= form.label :content, "投稿内容", class: "form-label fw-bold", style: "font-size: 1.3rem;" %>
               <div class="mt-2">
-                <%= form.text_area :content, class: "form-control form-control-lg w-100", rows: 8,
+                <%= form.text_area :content, class: "form-control form-control-lg w-100", rows: 6,
                     placeholder: "今日の習慣の取り組みや感想を書いてください...",
                     style: "font-size: 1.1rem; padding: 1rem; line-height: 1.6; resize: vertical; width: 70%;" %>
               </div>
@@ -45,6 +45,16 @@
                     placeholder: "画像のURLを入力してください（任意）",
                     style: "font-size: 1.1rem; padding: 1rem; width: 70%;" %>
                 <small class="form-text text-muted mt-2" style="font-size: 1rem;">習慣に関連する画像のURLを入力できます</small>
+              </div>
+            </div>
+
+            <div class="mb-5">
+              <%= form.label :tag_list, "タグ", class: "form-label fw-bold", style: "font-size: 1.3rem;" %>
+              <div class="mt-2">
+                <%= form.text_field :tag_list, class: "form-control form-control-lg w-100",
+                    placeholder: "勉強, 運動, 読書 (カンマ区切りで複数入力可)",
+                    style: "font-size: 1.1rem; padding: 1rem; width: 30%;" %>
+                <small class="form-text text-muted mt-2" style="font-size: 1rem;">タグをカンマ区切りで入力してください（例：勉強, 運動, 読書）</small>
               </div>
             </div>
 

--- a/db/migrate/20250908135052_create_tags.rb
+++ b/db/migrate/20250908135052_create_tags.rb
@@ -1,0 +1,10 @@
+class CreateTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tags do |t|
+      t.string :name
+
+      t.timestamps
+    end
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/migrate/20250908135154_create_post_tags.rb
+++ b/db/migrate/20250908135154_create_post_tags.rb
@@ -1,0 +1,12 @@
+class CreatePostTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :post_tags do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :post_tags, [:post_id, :tag_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_07_162304) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_08_135154) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,6 +39,16 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_07_162304) do
     t.index ["user_id"], name: "index_habits_on_user_id"
   end
 
+  create_table "post_tags", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id", "tag_id"], name: "index_post_tags_on_post_id_and_tag_id", unique: true
+    t.index ["post_id"], name: "index_post_tags_on_post_id"
+    t.index ["tag_id"], name: "index_post_tags_on_tag_id"
+  end
+
   create_table "posts", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "habit_id", null: false
@@ -50,6 +60,13 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_07_162304) do
     t.index ["habit_id"], name: "index_posts_on_habit_id"
     t.index ["user_id", "created_at"], name: "index_posts_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -68,6 +85,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_07_162304) do
   add_foreign_key "habit_records", "habits"
   add_foreign_key "habit_records", "users"
   add_foreign_key "habits", "users"
+  add_foreign_key "post_tags", "posts"
+  add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "habits"
   add_foreign_key "posts", "users"
 end

--- a/test/fixtures/post_tags.yml
+++ b/test/fixtures/post_tags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  post: one
+  tag: one
+
+two:
+  post: two
+  tag: two

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/post_tag_test.rb
+++ b/test/models/post_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
＃概要
タグ機能追加

- モデルの追加
・新たにtagモデル、posttagモデルを追加
・アソシエーションの記載
・タグパラメータとフィルタリング機能を処理できるように投稿コントローラーを修正

- viewファイル
・タグ入力フィールド: 新規投稿フォームと投稿編集フォームにプレースホルダーテキストと説明が追加
・ハッシュタグ表示: タグは、Bootstrap スタイルを使用して、クリック可能なハッシュタグ スタイルのバッジ (#勉強、#英語など) として表示
・タグフィルタリング: ユーザーは任意のタグをクリックして、そのタグで投稿をフィルタリング
・フィルター管理: フィルターをクリアしてすべての投稿の表示に戻るための「すべて表示」ボタンを追加