### PR TITLE
連続記録機能の修正

### DIFF
--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -22,7 +22,7 @@ class BadgesController < ApplicationController
        # Use optimized badge checker
       results = perform_badge_check_for_user(current_user)
 
-      # Set appropriate flash messages
+      # フラッシュメッセージ設定
       if results[:newly_earned].any?
         if results[:newly_earned].size == 1
           flash[:success] = "🎉 おめでとうございます！バッジ「#{results[:newly_earned].first.name}」を獲得しました！"

--- a/app/controllers/concerns/badge_checker.rb
+++ b/app/controllers/concerns/badge_checker.rb
@@ -95,57 +95,105 @@ module BadgeChecker
       0.0
     end
 
-    {
+    consecutive_days = calculate_max_consecutive_days(user)
+
+    stats = {
       total_habits: total_habits,
       total_records: user.habit_records.count,
       completed_records: completed_records,
-      consecutive_days: calculate_max_consecutive_days(user),
+      consecutive_days: consecutive_days,
       completion_rate: completion_rate
     }
+
+    Rails.logger.info "[BadgeCheck] Calculated stats for user #{user.id}: #{stats}"
+    stats
   end
 
   # Fast badge condition checking using pre-calculated stats
   def badge_earned_by_stats?(badge, user_stats)
     case badge.condition_type
     when 'consecutive_days'
-      user_stats[:consecutive_days] >= badge.condition_value
+      result = user_stats[:consecutive_days] >= badge.condition_value
+      Rails.logger.debug "[BadgeCheck] Badge '#{badge.name}' consecutive_days check: #{user_stats[:consecutive_days]} >= #{badge.condition_value} = #{result}"
+      result
     when 'total_habits'
-      user_stats[:total_habits] >= badge.condition_value
+      result = user_stats[:total_habits] >= badge.condition_value
+      Rails.logger.debug "[BadgeCheck] Badge '#{badge.name}' total_habits check: #{user_stats[:total_habits]} >= #{badge.condition_value} = #{result}"
+      result
     when 'total_records'
-      user_stats[:total_records] >= badge.condition_value
+      result = user_stats[:total_records] >= badge.condition_value
+      Rails.logger.debug "[BadgeCheck] Badge '#{badge.name}' total_records check: #{user_stats[:total_records]} >= #{badge.condition_value} = #{result}"
+      result
     when 'completion_rate'
-      user_stats[:completion_rate] >= badge.condition_value
+      result = user_stats[:completion_rate] >= badge.condition_value
+      Rails.logger.debug "[BadgeCheck] Badge '#{badge.name}' completion_rate check: #{user_stats[:completion_rate]} >= #{badge.condition_value} = #{result}"
+      result
     else
+       Rails.logger.warn "[BadgeCheck] Unknown badge condition type: #{badge.condition_type} for badge '#{badge.name}'"
       false
     end
   end
 
   # Optimized consecutive days calculation
   def calculate_max_consecutive_days(user)
-    # Since recorded_at is already a date field, we can use DISTINCT directly
-    records = user.habit_records.where(completed: true)
-                  .select('DISTINCT recorded_at')
-                  .order('recorded_at')
-                  .pluck('recorded_at')
+    # 各習慣ごとに最大連続日数を計算し、その中の最大値を返す
 
-    return 0 if records.empty?
+    Rails.logger.debug "[BadgeCheck] Starting per-habit consecutive days calculation for user #{user.id}"
+    return 0 if user.habits.empty?
+
+    max_consecutive_across_habits = 0
+
+    user.habits.each do |habit|
+      # この習慣の完了記録を日付順で取得
+      habit_dates = habit.habit_records.where(completed: true)
+                         .order(:recorded_at)
+                         .pluck(:recorded_at)
+
+      Rails.logger.debug "[BadgeCheck] Habit '#{habit.title}' (ID: #{habit.id}) has #{habit_dates.count} completed dates: #{habit_dates.join(', ')}"
+
+      next if habit_dates.empty?
+
+      # この習慣の最大連続日数を計算
+      habit_max_streak = calculate_consecutive_days_for_dates(habit_dates, habit.title)
+
+      Rails.logger.debug "[BadgeCheck] Habit '#{habit.title}' max streak: #{habit_max_streak}"
+
+      # 全体の最大値を更新
+      max_consecutive_across_habits = [max_consecutive_across_habits, habit_max_streak].max
+    end
+
+    Rails.logger.info "[BadgeCheck] Final max consecutive days for user #{user.id}: #{max_consecutive_across_habits} (max across all habits)"
+    max_consecutive_across_habits
+  rescue => e
+    Rails.logger.error "[BadgeCheck] Error calculating consecutive days: #{e.message}"
+    Rails.logger.error "[BadgeCheck] Backtrace: #{e.backtrace.first(3).join("\n")}"
+    0
+  end
+
+  # 日付配列から最大連続日数を計算するヘルパーメソッド
+  def calculate_consecutive_days_for_dates(dates, habit_name = "unknown")
+    return 0 if dates.empty?
+    return 1 if dates.length == 1
 
     max_streak = 1
     current_streak = 1
 
-    records.each_cons(2) do |prev_date, curr_date|
-      # Date型同士の減算は日数を返すため、1日差かをチェック
-      if (curr_date - prev_date).to_i == 1
+    dates.each_cons(2) do |prev_date, curr_date|
+      # 隣り合う日付を比較して「1日差」なら連続、それ以外はリセット
+      days_diff = (curr_date - prev_date).to_i
+      Rails.logger.debug "[BadgeCheck] Habit '#{habit_name}': Comparing #{prev_date} to #{curr_date}: diff = #{days_diff} days"
+
+      if days_diff == 1
         current_streak += 1
         max_streak = [max_streak, current_streak].max
+        Rails.logger.debug "[BadgeCheck] Habit '#{habit_name}': Consecutive! Current streak: #{current_streak}, max: #{max_streak}"
       else
         current_streak = 1
+        Rails.logger.debug "[BadgeCheck] Habit '#{habit_name}': Streak broken, reset to 1"
       end
     end
 
+    Rails.logger.debug "[BadgeCheck] Habit '#{habit_name}': Final max streak: #{max_streak}"
     max_streak
-  rescue => e
-    Rails.logger.error "[BadgeCheck] Error calculating consecutive days: #{e.message}"
-    0
   end
 end

--- a/app/controllers/concerns/badge_notifications.rb
+++ b/app/controllers/concerns/badge_notifications.rb
@@ -16,16 +16,21 @@ module BadgeNotifications
       end
     end
 
-    Rails.logger.debug "[BadgeNotifications] Stored badges in session: #{session[:newly_earned_badges].map { |b| b['name'] }.join(', ')}"
+    Rails.logger.info "[BadgeNotifications] Stored badges in session: #{session[:newly_earned_badges].map { |b| b['name'] }.join(', ')}"
   end
 
 
   # 保存された通知を取得してクリア（デバッグログ付き）
   def get_and_clear_badge_notifications
     return [] unless session[:newly_earned_badges].present?
+
     notifications = session[:newly_earned_badges].dup
+
     # セッションをクリア
     session.delete(:newly_earned_badges)
+
+    # セッションクリアを確実にするため、nilも設定
+    session[:newly_earned_badges] = nil
 
     # デバッグログ
     Rails.logger.info "Badge notifications cleared from session: #{notifications.map { |n| n['name'] }.join(', ')}" if notifications.any?
@@ -34,8 +39,15 @@ module BadgeNotifications
 
   # 通知フラッシュメッセージを設定（デバッグログ付き）
   def set_badge_notification_flash
-  # Turboリクエストではフラッシュしない
-    return if request.format.turbo_stream?
+    # Turboリクエストやajaxリクエストではフラッシュしない
+    return if request.format.turbo_stream? || request.xhr?
+
+    # セッションに通知がない場合は何もしない
+    return unless session[:newly_earned_badges].present?
+
+    # フラッシュが既に設定されている場合はスキップ（重複防止）
+    return if flash[:success].present? && flash[:success].include?('バッジ')
+
     notifications = get_and_clear_badge_notifications
     return if notifications.blank?
 
@@ -44,6 +56,6 @@ module BadgeNotifications
                       else
                         "🎉おめでとうございます! #{notifications.size}個のバッジを獲得しました！"
                       end
-    Rails.logger.debug "[BadgeNotifications] Flash set for badges: #{notifications.map { |n| n['name'] }.join(', ')}"
+    Rails.logger.info "[BadgeNotifications] Flash set for badges: #{notifications.map { |n| n['name'] }.join(', ')}"
   end
 end

--- a/app/controllers/habit_records_controller.rb
+++ b/app/controllers/habit_records_controller.rb
@@ -1,5 +1,5 @@
 class HabitRecordsController < ApplicationController
-include BadgeNotifications
+  include BadgeNotifications
 
   before_action :authenticate_user!
   before_action :set_habit
@@ -53,6 +53,11 @@ include BadgeNotifications
   # DELETE /habits/:habit_id/habit_records/:id
   def destroy
     @habit_record.destroy
+
+    # Check for badges after deletion as well (stats might have changed)
+    # Note: Don't set notifications for deletions to avoid confusing users
+    current_user.check_and_award_badges
+
     respond_to do |format|
       format.html { redirect_to calendar_habit_path(@habit), notice: '記録が削除されました。' }
       format.json { head :no_content }

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -1,6 +1,6 @@
 class HabitsController < ApplicationController
   include BadgeNotifications
-  
+
   before_action :authenticate_user!
   before_action :set_habit, only: [:show, :edit, :update, :destroy, :individual_calendar, :toggle_record_for_date]
 
@@ -31,6 +31,10 @@ class HabitsController < ApplicationController
       # Delete existing record (toggle from completed to unrecorded)
       record.destroy!
       Rails.logger.info "Deleted habit record for habit #{@habit.id}, date #{date}, user #{current_user.id}"
+
+       # Check for badges after deletion as well (stats might have changed)
+      # Note: Don't set notifications for deletions to avoid confusing users
+      current_user.check_and_award_badges
     else
       # Create new completed record
       new_record = @habit.habit_records.build(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,29 +28,36 @@ class User < ApplicationRecord
 
   # 統計メソッド（バッジ条件チェック用）
   def max_consecutive_days
-    # 最大連続日数を計算
+    # 各習慣ごとに最大連続日数を計算し、その中の最大値を返す
+    Rails.logger.debug "[User#max_consecutive_days] Starting calculation for user #{id}"
+    return 0 if habits.empty?
 
-    # 達成済みの記録だけを取得して、重複日を除去し、日付昇順に並べる
-    unique_dates = habit_records.where(completed: true)
-                                .select('DISTINCT recorded_at')
-                                .order(:recorded_at)
-                                .pluck(:recorded_at)
+    max_consecutive_across_habits = 0
 
-    return 0 if unique_dates.empty?
-    max_streak = 1 # 最大連続日数
-    current_streak = 1 # 現在の連続日数
+    habits.each do |habit|
+      # この習慣の完了記録を日付順で取得
+      habit_dates = habit.habit_records.where(completed: true)
+                         .order(:recorded_at)
+                         .pluck(:recorded_at)
+      Rails.logger.debug "[User#max_consecutive_days] Habit '#{habit.title}' (ID: #{habit.id}) has #{habit_dates.count} completed dates: #{habit_dates.join(', ')}"
 
-    unique_dates.each_cons(2) do |prev_date, curr_date|
-      # 隣り合う日付を比較して「1日差」なら連続、それ以外はリセット
-      if (curr_date - prev_date).to_i == 1
-        current_streak += 1
-        max_streak = [max_streak, current_streak].max
-      else
-        current_streak = 1
-      end
+      next if habit_dates.empty?
+
+      # この習慣の最大連続日数を計算
+      habit_max_streak = calculate_consecutive_days_for_dates(habit_dates, habit.title)
+
+      Rails.logger.debug "[User#max_consecutive_days] Habit '#{habit.title}' max streak: #{habit_max_streak}"
+
+      # 全体の最大値を更新
+      max_consecutive_across_habits = [max_consecutive_across_habits, habit_max_streak].max
     end
-    # 最大値を返す
-    max_streak
+     Rails.logger.info "[User#max_consecutive_days] Final result for user #{id}: #{max_consecutive_across_habits} (max across all habits)"
+     max_consecutive_across_habits
+
+  rescue => e
+    Rails.logger.error "[User#max_consecutive_days] Error: #{e.message}"
+    Rails.logger.error "[User#max_consecutive_days] Backtrace: #{e.backtrace.first(3).join("\n")}"
+    0
   end
 
   # 全習慣の完了率を計算
@@ -93,5 +100,34 @@ class User < ApplicationRecord
       # Return empty array on error
       []
     end
+  end
+
+  private
+
+  # 日付配列から最大連続日数を計算するヘルパーメソッド
+  def calculate_consecutive_days_for_dates(dates, habit_name = "unknown")
+    return 0 if dates.empty?
+    return 1 if dates.length == 1
+
+    max_streak = 1
+    current_streak = 1
+
+    dates.each_cons(2) do |prev_date, curr_date|
+      # 隣り合う日付を比較して「1日差」なら連続、それ以外はリセット
+      days_diff = (curr_date - prev_date).to_i
+      Rails.logger.debug "[User#calculate_consecutive_days_for_dates] Habit '#{habit_name}': Comparing #{prev_date} to #{curr_date}: diff = #{days_diff} days"
+
+      if days_diff == 1
+        current_streak += 1
+        max_streak = [max_streak, current_streak].max
+        Rails.logger.debug "[User#calculate_consecutive_days_for_dates] Habit '#{habit_name}': Consecutive! Current streak: #{current_streak}, max: #{max_streak}"
+      else
+        current_streak = 1
+        Rails.logger.debug "[User#calculate_consecutive_days_for_dates] Habit '#{habit_name}': Streak broken, reset to 1"
+      end
+    end
+
+    Rails.logger.debug "[User#calculate_consecutive_days_for_dates] Habit '#{habit_name}': Final max streak: #{max_streak}"
+    max_streak
   end
 end


### PR DESCRIPTION
＃概要
連続記録機能の修正

・連続記録日数を１つの習慣から取得するように修正。
・３日間継続バッジなど継続系のバッジを取得確認できた
