### PR TITLE
フラッシュメッセージ表示変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include BadgeNotifications
 
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :set_badge_notification_flash, if: :user_signed_in?
+  after_action :set_badge_notification_flash, if: :user_signed_in?
 
   private
 

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -13,41 +13,4 @@ class BadgesController < ApplicationController
     @users_with_badge = @badge.users.limit(10)
     @user_badge = current_user.user_badges.find_by(badge: @badge) if current_user.has_badge?(@badge)
   end
-
-  # 手動でバッジチェックを実行（開発用）
-  def check_awards
-     Rails.logger.info "[BadgesController] Badge check started for user #{current_user.id} at #{Time.current}"
-
-    begin
-       # Use optimized badge checker
-      results = perform_badge_check_for_user(current_user)
-
-      # Set appropriate flash messages
-      if results[:newly_earned].any?
-        if results[:newly_earned].size == 1
-          flash[:success] = "🎉 おめでとうございます！バッジ「#{results[:newly_earned].first.name}」を獲得しました！"
-        else
-          flash[:success] = "おめでとうございます、#{results[:newly_earned].size}個のバッジを獲得しました！"
-        end
-      else
-        stats = results[:stats]
-        flash[:success] = "バッジチェック完了！現在の統計: 習慣#{stats[:total_habits]}個、獲得バッジ#{current_user.user_badges.count}個、記録#{stats[:total_records]}個（完了率#{stats[:completion_rate]}%）"
-      end
-
-       # Log any errors but don't fail the request
-      if results[:errors].any?
-        Rails.logger.warn "[BadgesController] Badge check had #{results[:errors].count} errors: #{results[:errors].join(', ')}"
-        flash[:warning] = "一部のバッジのチェックでエラーが発生しましたが、処理は完了しました。"
-      end
-
-    rescue => e
-      Rails.logger.error "[BadgesController] Badge check failed for user #{current_user.id}: #{e.message}"
-      Rails.logger.error "[BadgesController] Backtrace: #{e.backtrace.first(5).join("\n")}"
-      flash[:alert] = "バッジチェック中にエラーが発生しました。もう一度お試しください。"
-    ensure
-      # Always redirect to prevent hanging
-      Rails.logger.info "[BadgesController] Redirecting to badges_path for user #{current_user.id}"
-      redirect_to badges_path and return
-    end
-  end
 end

--- a/app/controllers/concerns/badge_notifications.rb
+++ b/app/controllers/concerns/badge_notifications.rb
@@ -9,6 +9,8 @@ module BadgeNotifications
     return if badges.blank?
     session[:newly_earned_badges] ||= []
 
+     Rails.logger.debug "[BadgeNotifications] Before adding, session contains: #{session[:newly_earned_badges].map { |b| b['name'] }.join(', ')}"
+
     badges.each do |badge|
       badge_data = { id: badge.id, name: badge.name }
       unless session[:newly_earned_badges].any? { |b| b['id'] == badge.id }
@@ -34,16 +36,18 @@ module BadgeNotifications
 
   # 通知フラッシュメッセージを設定（デバッグログ付き）
   def set_badge_notification_flash
-  # Turboリクエストではフラッシュしない
+  # Turboリクエストではフラッシュを使わない
     return if request.format.turbo_stream?
+
     notifications = get_and_clear_badge_notifications
     return if notifications.blank?
 
     flash[:success] = if notifications.size == 1
-                        "🎉おめでとうございます! バッジ「#{notifications.first['name']}」を獲得しました！"
+                        "🎉ccccおめでとうございます! バッジ「#{notifications.first['name']}」を獲得しました！"
                       else
-                        "🎉おめでとうございます! #{notifications.size}個のバッジを獲得しました！"
+                        "🎉ccccおめでとうございます! #{notifications.size}個のバッジを獲得しました！"
                       end
+
     Rails.logger.debug "[BadgeNotifications] Flash set for badges: #{notifications.map { |n| n['name'] }.join(', ')}"
   end
 end

--- a/app/controllers/habit_records_controller.rb
+++ b/app/controllers/habit_records_controller.rb
@@ -1,5 +1,5 @@
 class HabitRecordsController < ApplicationController
-include BadgeNotifications
+  include BadgeNotifications
 
   before_action :authenticate_user!
   before_action :set_habit

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -1,6 +1,6 @@
 class HabitsController < ApplicationController
   include BadgeNotifications
-  
+
   before_action :authenticate_user!
   before_action :set_habit, only: [:show, :edit, :update, :destroy, :individual_calendar, :toggle_record_for_date]
 
@@ -15,6 +15,7 @@ class HabitsController < ApplicationController
     @habit_records = @habit.habit_records.includes(:habit)
   end
 
+  # 日付を指定して記録をトグル（完了⇔未記録）
   def toggle_record_for_date
     begin
       date = Date.parse(params[:date])
@@ -28,11 +29,11 @@ class HabitsController < ApplicationController
     record = @habit.habit_records.find_by(recorded_at: date, user: current_user)
 
     if record
-      # Delete existing record (toggle from completed to unrecorded)
+      # 既存の記録があれば削除（未記録に戻す）
       record.destroy!
       Rails.logger.info "Deleted habit record for habit #{@habit.id}, date #{date}, user #{current_user.id}"
     else
-      # Create new completed record
+      # 新しい完了記録を作成
       new_record = @habit.habit_records.build(
         user: current_user,
         recorded_at: date,
@@ -72,14 +73,16 @@ class HabitsController < ApplicationController
   end
 
   def create
-    @habit = current_user.habits.build(habit_params)
+  @habit = current_user.habits.build(habit_params)
 
     if @habit.save
-      # バッジ獲得チェックと通知設定
-      newly_earned_badges = current_user.check_and_award_badges
-      set_badge_notification(newly_earned_badges) if newly_earned_badges.any?
+      flash[:success] = "習慣が作成されました！"
 
-      redirect_to @habit, notice: '習慣が正常に作成されました。'
+      # バッジチェック実行（通知は session に積むだけ）
+      newly_earned = current_user.check_and_award_badges
+      set_badge_notification(newly_earned) if newly_earned.any?
+
+      redirect_to habits_path
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,30 +28,27 @@ class User < ApplicationRecord
 
   # 統計メソッド（バッジ条件チェック用）
   def max_consecutive_days
-    # 最大連続日数を計算
+  unique_dates = habit_records.where(completed: true)
+                              .pluck(:recorded_at)
+                              .uniq
+                              .sort
 
-    # 達成済みの記録だけを取得して、重複日を除去し、日付昇順に並べる
-    unique_dates = habit_records.where(completed: true)
-                                .select('DISTINCT recorded_at')
-                                .order(:recorded_at)
-                                .pluck(:recorded_at)
+  return 0 if unique_dates.empty?
 
-    return 0 if unique_dates.empty?
-    max_streak = 1 # 最大連続日数
-    current_streak = 1 # 現在の連続日数
+  max_streak = 1
+  current_streak = 1
 
-    unique_dates.each_cons(2) do |prev_date, curr_date|
-      # 隣り合う日付を比較して「1日差」なら連続、それ以外はリセット
-      if (curr_date - prev_date).to_i == 1
-        current_streak += 1
-        max_streak = [max_streak, current_streak].max
-      else
-        current_streak = 1
-      end
+  unique_dates.each_cons(2) do |prev_date, curr_date|
+    if (curr_date - prev_date).to_i == 1
+      current_streak += 1
+      max_streak = [max_streak, current_streak].max
+    else
+      current_streak = 1
     end
-    # 最大値を返す
-    max_streak
   end
+
+  max_streak
+end
 
   # 全習慣の完了率を計算
   def overall_completion_rate


### PR DESCRIPTION
＃概要
フラッシュメッセージ表示変更

・習慣記録を完了にしてバッジ付与条件を満たしていれば(３日間継続して記録しているなど)、即座にフラッシュメッセージが通知されるよう変更。

・習慣作成がされた際に、バッジ付与条件を満たしていれば、「習慣が作成されました」の通知の次のページでバッジ獲得のフラッシュメッセージが通知されるよう変更。