### PR TITLE
CIファイル修正

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -14,16 +14,31 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Install Ruby and gems
-        uses: ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
         with:
+          ruby-version: 3.2 # プロジェクトの Ruby バージョンに合わせる
           bundler-cache: true
+
+      - name: Install required Bundler version
+        run: |
+          required=$(ruby -e "puts File.read('Gemfile.lock')[/\n\nBUNDLED WITH\n +([^\n]+)/, 1]")
+          echo "Installing Bundler $required"
+          gem install bundler -v "$required"
+
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+
       - name: Generate binstubs
-        run: bundle binstubs bundler-audit brakeman rubocop
-      # Add or replace any other lints here
+        run: bundle binstubs bundler-audit brakeman rubocop --force
+
+      # Linter / Security
       - name: Security audit dependencies
         run: bin/bundler-audit --update
+
       - name: Security audit application code
         run: bin/brakeman -q -w2
+
       - name: Lint Ruby files
         run: bin/rubocop --parallel


### PR DESCRIPTION
＃概要
CIファイル修正

binstub を生成する前に Bundler のバージョンを確認・インストールしていないためLintチェックが通らないので、通るようにファイル修正