### PR TITLE
ワークフローファイル修正２

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -33,12 +33,12 @@ jobs:
       - name: Generate binstubs
         run: bundle binstubs bundler-audit brakeman rubocop --force
 
-      # Linter / Security
       - name: Security audit dependencies
-        run: bin/bundler-audit --update
+        run: bundle exec bundler-audit --update
 
       - name: Security audit application code
-        run: bin/brakeman -q -w2
+        run: bundle exec brakeman -q -w2
 
       - name: Lint Ruby files
-        run: bin/rubocop --parallel
+        run: bundle exec rubocop --parallel
+        


### PR DESCRIPTION
＃概要
ワークフローファイル修正２

ワークフローファイルでbinstub を使わず、bundle exec で直接実行するよう修正