### PR TITLE
本番環境でのパスワードリセット機能

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'noreply@loopin-app.com'
   layout 'mailer'
 end

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,5 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>こんにちは <%= @resource.email %>さん!</p>
 
-<p>We're contacting you to notify you that your password has been changed.</p>
+<p>パスワードが正常に変更されました。</p>
+
+<p>このメールに心当たりがない場合は、すぐにお問い合わせください。</p>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,11 +75,22 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Ensure mail delivery method is set to prevent issues
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
+
+  # SMTP settings for sending emails in production
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch('SMTP_ADDRESS', 'smtp.gmail.com'),
+    port: ENV.fetch('SMTP_PORT', 587).to_i,
+    domain: ENV.fetch('SMTP_DOMAIN', 'original-app-loopin.onrender.com'),
+    user_name: ENV.fetch('SMTP_USERNAME', nil),
+    password: ENV.fetch('SMTP_PASSWORD', nil),
+    authentication: ENV.fetch('SMTP_AUTHENTICATION', 'plain'),
+    enable_starttls_auto: ENV.fetch('SMTP_ENABLE_STARTTLS_AUTO', true)
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/docs/PASSWORD_RESET_SETUP.md
+++ b/docs/PASSWORD_RESET_SETUP.md
@@ -1,0 +1,116 @@
+# パスワードリセット機能のセットアップガイド
+
+## 概要
+
+本番環境でパスワードリセット機能を有効にするためのガイドです。この機能により、ユーザーはメールを介してパスワードをリセットできます。
+
+## 必要な環境変数
+
+本番環境（Render等）で以下の環境変数を設定してください：
+
+| 環境変数名 | 説明 | 例 |
+|-----------|------|-----|
+| `SMTP_ADDRESS` | SMTPサーバーのアドレス | `smtp.gmail.com` |
+| `SMTP_PORT` | SMTPポート番号 | `587` |
+| `SMTP_DOMAIN` | アプリケーションのドメイン | `original-app-loopin.onrender.com` |
+| `SMTP_USERNAME` | SMTP認証用のユーザー名（通常はメールアドレス） | `your-email@gmail.com` |
+| `SMTP_PASSWORD` | SMTP認証用のパスワード | `your-app-password` |
+| `SMTP_AUTHENTICATION` | 認証方式 | `plain` |
+| `SMTP_ENABLE_STARTTLS_AUTO` | STARTTLS自動有効化 | `true` |
+
+## Gmail を使用する場合
+
+### 1. Googleアカウントで2段階認証を有効化
+1. [Googleアカウント](https://myaccount.google.com/)にログイン
+2. 「セキュリティ」→「2段階認証プロセス」を有効化
+
+### 2. アプリパスワードの生成
+1. [アプリパスワード](https://myaccount.google.com/apppasswords)にアクセス
+2. アプリ名を入力（例：「Loopin Production」）
+3. 「生成」をクリック
+4. 生成された16文字のパスワードをコピー
+
+### 3. Renderで環境変数を設定
+1. Renderダッシュボードにログイン
+2. アプリケーションを選択
+3. 「Environment」タブを開く
+4. 以下の環境変数を追加：
+   ```
+   SMTP_ADDRESS=smtp.gmail.com
+   SMTP_PORT=587
+   SMTP_DOMAIN=original-app-loopin.onrender.com
+   SMTP_USERNAME=your-email@gmail.com
+   SMTP_PASSWORD=生成したアプリパスワード
+   SMTP_AUTHENTICATION=plain
+   SMTP_ENABLE_STARTTLS_AUTO=true
+   ```
+5. 「Save Changes」をクリック
+6. アプリケーションが自動的に再デプロイされます
+
+## その他のSMTPプロバイダー
+
+### SendGrid
+```
+SMTP_ADDRESS=smtp.sendgrid.net
+SMTP_PORT=587
+SMTP_USERNAME=apikey
+SMTP_PASSWORD=your-sendgrid-api-key
+```
+
+### Mailgun
+```
+SMTP_ADDRESS=smtp.mailgun.org
+SMTP_PORT=587
+SMTP_USERNAME=postmaster@your-domain.mailgun.org
+SMTP_PASSWORD=your-mailgun-password
+```
+
+### Amazon SES
+```
+SMTP_ADDRESS=email-smtp.us-east-1.amazonaws.com
+SMTP_PORT=587
+SMTP_USERNAME=your-ses-smtp-username
+SMTP_PASSWORD=your-ses-smtp-password
+```
+
+## 使用方法
+
+### ユーザー側の操作
+1. ログインページにアクセス
+2. 「パスワードを忘れた方はこちら」リンクをクリック
+3. 登録済みのメールアドレスを入力
+4. 「パスワード再設定メールを送信」ボタンをクリック
+5. メールに記載されたリンクをクリック
+6. 新しいパスワードを入力して設定
+
+### 管理者による確認
+- 開発環境では、`letter_opener_web`が有効で、メールは`/letter_opener`で確認できます
+- 本番環境では、実際にメールが送信されます
+
+## トラブルシューティング
+
+### メールが送信されない
+1. 環境変数が正しく設定されているか確認
+2. SMTPパスワードが正しいか確認（Gmailの場合、通常のパスワードではなくアプリパスワードを使用）
+3. Renderのログを確認：`View Logs`から配信エラーを確認
+
+### リセットリンクが機能しない
+1. リセットトークンの有効期限（6時間）を確認
+2. `config.action_mailer.default_url_options`が正しいドメインを指しているか確認
+
+### OAuthユーザー（Googleログイン）について
+- OAuthで登録したユーザーはパスワードを持たないため、パスワードリセットは実質的に無効です
+- しかし、セキュリティのため、リクエスト時に同じメッセージを返します
+
+## セキュリティ考慮事項
+
+1. **メールアドレスの存在確認**: セキュリティのため、メールアドレスが存在するかどうかにかかわらず、同じメッセージを表示します
+2. **トークンの有効期限**: リセットトークンは6時間で期限切れになります
+3. **HTTPS必須**: 本番環境では必ずHTTPSを使用してください（Renderではデフォルトで有効）
+4. **パスワード強度**: 最低6文字以上のパスワードが必要です
+
+## 参考リンク
+
+- [Devise公式ドキュメント](https://github.com/heartcombo/devise)
+- [Action Mailer ガイド](https://guides.rubyonrails.org/action_mailer_basics.html)
+- [Gmailアプリパスワード](https://myaccount.google.com/apppasswords)

--- a/spec/system/password_reset_spec.rb
+++ b/spec/system/password_reset_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe 'パスワードリセット', type: :system do
+  before do
+    driven_by(:remote_chrome)
+  end
+
+  let!(:user) { create(:user, email: 'test@example.com', password: 'password123') }
+
+  describe 'パスワードリセットリクエスト' do
+    it 'パスワードリセットページにアクセスできること' do
+      visit new_user_password_path
+
+      expect(page).to have_content('パスワード再設定')
+      expect(page).to have_field('メールアドレス')
+      expect(page).to have_button('パスワード再設定メールを送信')
+    end
+
+    it 'パスワードリセットメールをリクエストできること' do
+      visit new_user_password_path
+
+      fill_in 'メールアドレス', with: 'test@example.com'
+
+      # メールが送信されることを確認
+      expect {
+        click_button 'パスワード再設定メールを送信'
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(page).to have_content('パスワードの再設定について数分以内にメールでご連絡いたします。')
+    end
+
+    it '登録されていないメールアドレスでもエラーを表示しないこと（セキュリティのため）' do
+      visit new_user_password_path
+
+      fill_in 'メールアドレス', with: 'nonexistent@example.com'
+      click_button 'パスワード再設定メールを送信'
+
+      # Deviseのデフォルトではメールアドレスが存在しない場合でも同じメッセージを表示
+      expect(page).to have_content('パスワードの再設定について数分以内にメールでご連絡いたします。')
+    end
+  end
+
+  describe 'パスワードリセット実行' do
+    it 'リセットトークンを使用して新しいパスワードを設定できること' do
+      # パスワードリセットトークンを生成
+      token = user.send_reset_password_instructions
+
+      # パスワード編集ページにアクセス
+      visit edit_user_password_path(reset_password_token: token)
+
+      expect(page).to have_content('新しいパスワード設定')
+
+      # 新しいパスワードを入力
+      fill_in 'user[password]', with: 'newpassword123'
+      fill_in 'user[password_confirmation]', with: 'newpassword123'
+
+      click_button 'パスワードを変更'
+
+      expect(page).to have_content('パスワードが正しく変更されました。')
+
+      # 新しいパスワードでログインできることを確認
+      click_link 'ログアウト' if page.has_link?('ログアウト')
+
+      visit new_user_session_path
+      fill_in 'メールアドレス', with: 'test@example.com'
+      fill_in 'パスワード', with: 'newpassword123'
+      click_button 'ログイン'
+
+      expect(page).to have_content('ログインしました。')
+    end
+
+    it 'パスワードが短すぎる場合はエラーが表示されること' do
+      token = user.send_reset_password_instructions
+
+      visit edit_user_password_path(reset_password_token: token)
+
+      fill_in 'user[password]', with: '123'
+      fill_in 'user[password_confirmation]', with: '123'
+
+      click_button 'パスワードを変更'
+
+      expect(page).to have_content('は6文字以上で入力してください')
+    end
+
+    it 'パスワードと確認が一致しない場合はエラーが表示されること' do
+      token = user.send_reset_password_instructions
+
+      visit edit_user_password_path(reset_password_token: token)
+
+      fill_in 'user[password]', with: 'newpassword123'
+      fill_in 'user[password_confirmation]', with: 'differentpassword'
+
+      click_button 'パスワードを変更'
+
+      expect(page).to have_content('と確認用パスワードの入力が一致しません')
+    end
+  end
+
+  describe 'OAuthユーザー' do
+    let!(:oauth_user) { create(:user, provider: 'google_oauth2', uid: '123456', email: 'oauth@example.com') }
+
+    it 'OAuthユーザーはパスワードリセットをリクエストしても影響がないこと' do
+      # OAuthユーザーはパスワードを持たないため、リセットは無意味だが
+      # システムとしては正常にメッセージを返す（セキュリティのため）
+      visit new_user_password_path
+
+      fill_in 'メールアドレス', with: 'oauth@example.com'
+      click_button 'パスワード再設定メールを送信'
+
+      expect(page).to have_content('パスワードの再設定について数分以内にメールでご連絡いたします。')
+    end
+  end
+end


### PR DESCRIPTION
＃概要
本番環境でのパスワードリセット機能

実装内容
1. 本番環境SMTP設定の追加
config/environments/production.rbに環境変数経由でSMTP設定を追加しました。これにより、Gmail、SendGrid、Mailgun、Amazon SESなど、様々なSMTPプロバイダーに対応可能です。

config.action_mailer.smtp_settings = {
  address: ENV.fetch('SMTP_ADDRESS', 'smtp.gmail.com'),
  port: ENV.fetch('SMTP_PORT', 587).to_i,
  domain: ENV.fetch('SMTP_DOMAIN', 'original-app-loopin.onrender.com'),
  user_name: ENV.fetch('SMTP_USERNAME', nil),
  password: ENV.fetch('SMTP_PASSWORD', nil),
  authentication: ENV.fetch('SMTP_AUTHENTICATION', 'plain'),
  enable_starttls_auto: ENV.fetch('SMTP_ENABLE_STARTTLS_AUTO', true)
}

2. テストの追加
本番環境でのパスワードリセットのテスト追加

3.
本番環境(Render)での環境変数追加
