### PR TITLE
本番環境でのパスワードリセット機能修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,7 +89,7 @@ Rails.application.configure do
     user_name: ENV.fetch('SMTP_USERNAME', nil),
     password: ENV.fetch('SMTP_PASSWORD', nil),
     authentication: ENV.fetch('SMTP_AUTHENTICATION', 'plain'),
-    enable_starttls_auto: ENV.fetch('SMTP_ENABLE_STARTTLS_AUTO', true)
+    enable_starttls_auto: ENV.fetch('SMTP_ENABLE_STARTTLS_AUTO', 'true') == 'true'
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to


### PR DESCRIPTION
＃概要
本番環境でのパスワードリセット機能修正

config/environments/production.rbの
enable_starttls_auto: ENV.fetch('SMTP_ENABLE_STARTTLS_AUTO', true)のtrueが文字列として認識していてエラーが出たので、
enable_starttls_auto: ENV.fetch('SMTP_ENABLE_STARTTLS_AUTO', 'true') == 'true'に変更